### PR TITLE
fix: package manager feature 

### DIFF
--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -547,30 +547,14 @@ const createFileUpload = async (
 
 const checkIfPackageManagerIsAvailable = (cmd: string): boolean => {
   try {
-    execSync(`command -v ${cmd}`, { stdio: 'ignore' });
+    execSync(`${cmd} -v`, { stdio: 'ignore' });
     return true;
   } catch (error) {
     return false;
   }
 };
 
-const installNpm = (): void => {
-  try {
-    const currentPlatform = platform();
-    if (currentPlatform === 'win32') {
-      // Windows installation command for npm via Node.js installer
-      console.log('Downloading and installing Node.js which includes npm...');
-      execSync('powershell -Command "Invoke-WebRequest -Uri https://nodejs.org/dist/v18.16.1/node-v18.16.1-x64.msi -OutFile nodejs.msi; Start-Process msiexec.exe -ArgumentList \'/i nodejs.msi /quiet\' -Wait; Remove-Item nodejs.msi"', { stdio: 'inherit' });
-    } else {
-      // Linux/macOS installation command for npm
-      execSync('curl -L https://www.npmjs.com/install.sh | sh', { stdio: 'inherit' });
-    }
-    console.log('npm has been installed.');
-  } catch (error) {
-    console.error('Failed to install npm:', error);
-    process.exit(1); 
-  }
-};
+
 
 const askForPackageManager = async (): Promise<Answers> => {
   const availablePackageManagers = [
@@ -580,11 +564,7 @@ const askForPackageManager = async (): Promise<Answers> => {
     PackageManager.BUN
   ].filter(pm => checkIfPackageManagerIsAvailable(pm));
 
-  if (availablePackageManagers.length === 0) {
-    console.log('No package managers found. Installing npm...');
-    installNpm();
-    return { packageManager: PackageManager.NPM };
-  }
+  
 
   const questions: Question[] = [
     generateSelect('packageManager')(MESSAGES.PACKAGE_MANAGER_QUESTION)(availablePackageManagers),

--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -544,15 +544,34 @@ const createFileUpload = async (
 
 //ASK FOR INPUTS
 
+const checkIfPackageManagerIsAvailable = (cmd: string): boolean => {
+  try {
+    execSync(`command -v ${cmd}`, { stdio: 'ignore' });
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
+
 const askForPackageManager = async (): Promise<Answers> => {
+  const availablePackageManagers = [
+    PackageManager.NPM,
+    PackageManager.YARN,
+    PackageManager.PNPM,
+    PackageManager.BUN
+  ].filter(pm => checkIfPackageManagerIsAvailable(pm));
+
+  if (availablePackageManagers.length === 0) {
+    console.log('No package managers found. Installing npm...');
+    // You can add logic here to install npm if needed.
+    return { packageManager: PackageManager.NPM };
+  }
+
   const questions: Question[] = [
-    generateSelect('packageManager')(MESSAGES.PACKAGE_MANAGER_QUESTION)([
-      PackageManager.NPM,
-      PackageManager.YARN,
-      PackageManager.PNPM,
-      PackageManager.BUN
-    ]),
+    generateSelect('packageManager')(MESSAGES.PACKAGE_MANAGER_QUESTION)(availablePackageManagers),
   ];
+
   const prompt = inquirer.createPromptModule();
   return await prompt(questions);
 };

--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -29,6 +29,7 @@ import { ClassMonitoring } from '../lib/monitoring';
 import { ClassTemporal } from '../lib/temporal';
 import { ClassLogging } from '../lib/logging';
 import { ClassFileUpload } from '../lib/fileUpload';
+import { platform } from 'os';
 
 export class NewAction extends AbstractAction {
   public async handle(inputs: Input[], options: Input[]) {
@@ -553,6 +554,23 @@ const checkIfPackageManagerIsAvailable = (cmd: string): boolean => {
   }
 };
 
+const installNpm = (): void => {
+  try {
+    const currentPlatform = platform();
+    if (currentPlatform === 'win32') {
+      // Windows installation command for npm via Node.js installer
+      console.log('Downloading and installing Node.js which includes npm...');
+      execSync('powershell -Command "Invoke-WebRequest -Uri https://nodejs.org/dist/v18.16.1/node-v18.16.1-x64.msi -OutFile nodejs.msi; Start-Process msiexec.exe -ArgumentList \'/i nodejs.msi /quiet\' -Wait; Remove-Item nodejs.msi"', { stdio: 'inherit' });
+    } else {
+      // Linux/macOS installation command for npm
+      execSync('curl -L https://www.npmjs.com/install.sh | sh', { stdio: 'inherit' });
+    }
+    console.log('npm has been installed.');
+  } catch (error) {
+    console.error('Failed to install npm:', error);
+    process.exit(1); 
+  }
+};
 
 const askForPackageManager = async (): Promise<Answers> => {
   const availablePackageManagers = [
@@ -564,7 +582,7 @@ const askForPackageManager = async (): Promise<Answers> => {
 
   if (availablePackageManagers.length === 0) {
     console.log('No package managers found. Installing npm...');
-    // You can add logic here to install npm if needed.
+    installNpm();
     return { packageManager: PackageManager.NPM };
   }
 


### PR DESCRIPTION
Issue : #29 

Functionality added :   `stencil new` will check for installed package managers and then ask user to choose from only those which are installed. 

Default case: it'll ask to install `npm`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
