### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Stencil CLI is a command-line interface tool that helps you to initialize, d
 
 The CLI works with [schematics](https://github.com/angular/angular-cli/tree/master/packages/angular_devkit/schematics), and provides built in support from the schematics collection at [@samagra-x/schematics](https://github.com/SamagraX-stencil/schematics).
 
-Read more [here](https://stencil.samagra.io/cli/introduction).
+Read more [here](https://stencil-docs.vercel.app/cli/introduction).
 
 ## Installation
 
@@ -14,11 +14,11 @@ $ npm install -g @samagra-x/stencil-cli
 
 ## Usage
 
-Learn more in the [official documentation](https://stencil.samagra.io/cli/introduction).
+Learn more in the [official documentation](https://stencil-docs.vercel.app/cli/introduction).
 
 ## Stay in touch
 
-- Website - [https://stencil.samagra.io/](https://stencil.samagra.io/cli/introduction/)
+- Website - [https://stencil.samagra.io/](https://stencil-docs.vercel.app/cli/introduction)
 
 
 ## Mentions


### PR DESCRIPTION
fixed the docs link redirecting to the old docs website

## PR Type
[x] Bugfix

## What is the current behavior?
Cli-docs link redirecting to the old docs website

## What is the new behavior?
Cli-docs link redirecting to the current docs website

## Does this PR introduce a breaking change?
[ x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated URLs in the documentation links for the Stencil CLI to `https://stencil-docs.vercel.app`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->