### PR TITLE
Fix broken cli

### DIFF
--- a/lib/package-managers/abstract.package-manager.ts
+++ b/lib/package-managers/abstract.package-manager.ts
@@ -9,6 +9,7 @@ import { PackageManagerCommands } from './package-manager-commands';
 import { ProjectDependency } from './project.dependency';
 import { NpxRunner } from '../runners/npx.runner';
 import { StencilRunner } from '../runners/stencil.runner';
+import { execSync } from 'child_process';
 
 export abstract class AbstractPackageManager {
   constructor(protected runner: AbstractRunner) {}
@@ -29,6 +30,7 @@ export abstract class AbstractPackageManager {
     });
     spinner.start();
     try {
+      await this.linkPackages(directory);
       const commandArgs = `${this.cli.install} ${this.cli.silentFlag}`;
       const collect = true;
       const normalizedDirectory = normalizeToKebabOrSnakeCase(directory);
@@ -104,6 +106,19 @@ export abstract class AbstractPackageManager {
       );
     }
   }
+public async linkPackages (normalizedDirectory: string) : Promise<void> {
+  try {
+    execSync('npm link @samagra-x/schematics @samagra-x/stencil-cli', {
+      cwd: join(process.cwd(), normalizedDirectory),
+      stdio: 'pipe',
+    }); 
+
+  } catch (error) {
+    if (error && error.message) {
+      console.error(chalk.red(error.message));
+    }
+  }
+}
 
   public async version(): Promise<string> {
     const commandArguments = '--version';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] 
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Right now the `stencil-cli` while installing packages looks for `schematics` from the npm.
A temporary fix to this is `npm link` inside the cli installation process.
Once the dev branch of cli & schematics is released, we can revert this changes.

https://github.com/user-attachments/assets/e78585dc-8de4-4147-8d41-d627b7e9d4be



## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
